### PR TITLE
Add support for vivado 2025.1

### DIFF
--- a/vivado/auto_create_project/create_project.bat
+++ b/vivado/auto_create_project/create_project.bat
@@ -1,2 +1,2 @@
-CALL E:\XilinxVitis\Vivado\2020.1\bin\vivado.bat -mode batch -source create_project.tcl
+CALL D:\apps\Xilinx\2025.1\Vivado\bin\vivado.bat -mode batch -source create_project.tcl
 PAUSE

--- a/vivado/auto_create_project/create_project.tcl
+++ b/vivado/auto_create_project/create_project.tcl
@@ -66,7 +66,7 @@ create_bd_design $bdname
 
 open_bd_design $projpath/$projName.srcs/sources_1/bd/$bdname/$bdname.bd
 
-create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.3 zynq_ultra_ps_e_0
+create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.5 zynq_ultra_ps_e_0
 
 source $projpath/auto_create_project/ps_config.tcl
 set_ps_config zynq_ultra_ps_e_0
@@ -89,8 +89,8 @@ validate_bd_design
 save_bd_design		 
 
 make_wrapper -files [get_files $projpath/$projName.srcs/sources_1/bd/$bdname/$bdname.bd] -top
-# add_files -norecurse $projpath/$projName.srcs/sources_1/bd/$bdname/hdl/$bdWrapperName.v 
-add_files -norecurse [glob -nocomplain $projpath/$projName.srcs/sources_1/bd/$bdname/hdl/*.v]
+# add_files -norecurse $projpath/$projName.gen/sources_1/bd/$bdname/hdl/$bdWrapperName.v 
+add_files -norecurse [glob -nocomplain $projpath/$projName.gen/sources_1/bd/$bdname/hdl/*.v]
 
 puts $bdname
 append bdWrapperName $bdname "_wrapper"

--- a/vivado/auto_create_project/pl_config.tcl
+++ b/vivado/auto_create_project/pl_config.tcl
@@ -168,7 +168,7 @@
  ] $frmbuf_wr_rst_gpio
 
   # Create instance: mipi_csi2_rx_subsyst_0, and set properties
-  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:5.0 mipi_csi2_rx_subsyst_0 ]
+  set mipi_csi2_rx_subsyst_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:mipi_csi2_rx_subsystem:6.0 mipi_csi2_rx_subsyst_0 ]
   set_property -dict [ list \
    CONFIG.CLK_LANE_IO_LOC {W8} \
    CONFIG.CMN_NUM_LANES {2} \
@@ -225,7 +225,7 @@
   set rst_ps8_0_200M [ create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset:5.0 rst_ps8_0_200M ]
 
   # Create instance: util_ds_buf_0, and set properties
-  set util_ds_buf_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.1 util_ds_buf_0 ]
+  set util_ds_buf_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.2 util_ds_buf_0 ]
 
   # Create instance: util_vector_logic_1, and set properties
   set util_vector_logic_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_vector_logic:2.0 util_vector_logic_1 ]
@@ -235,7 +235,7 @@
  ] $util_vector_logic_1
 
   # Create instance: v_frmbuf_wr_0, and set properties
-  set v_frmbuf_wr_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:2.1 v_frmbuf_wr_0 ]
+  set v_frmbuf_wr_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_frmbuf_wr:3.0 v_frmbuf_wr_0 ]
   set_property -dict [ list \
    CONFIG.HAS_UYVY8 {1} \
    CONFIG.HAS_YUYV8 {1} \
@@ -246,7 +246,7 @@
  ] $v_frmbuf_wr_0
 
   # Create instance: v_proc_ss_0, and set properties
-  set v_proc_ss_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_proc_ss:2.2 v_proc_ss_0 ]
+  set v_proc_ss_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:v_proc_ss:2.3 v_proc_ss_0 ]
   set_property -dict [ list \
    CONFIG.C_COLORSPACE_SUPPORT {1} \
    CONFIG.C_MAX_COLS {1920} \


### PR DESCRIPTION
Compile result on success:

```text
Verilog Output written to : C:/Users/yb/code/AXU2CG-E_AXU3EG_AXU4EV-E_AXU5EV-E/vivado/axu3eg_trd.gen/sources_1/bd/design_1/sim/design_1.v
Verilog Output written to : C:/Users/yb/code/AXU2CG-E_AXU3EG_AXU4EV-E_AXU5EV-E/vivado/axu3eg_trd.gen/sources_1/bd/design_1/hdl/design_1_wrapper.v
# add_files -norecurse [glob -nocomplain $projpath/$projName.gen/sources_1/bd/$bdname/hdl/*.v]
# puts $bdname
design_1
# append bdWrapperName $bdname "_wrapper"
# puts $bdWrapperName
design_1_wrapper
# set_property top $bdWrapperName [current_fileset]
# add_files -fileset constrs_1  -copy_to $projpath/$projName.srcs/constrs_1/new -force -quiet [glob -nocomplain $src_dir/constraints/*.xdc]
INFO: [Common 17-206] Exiting Vivado at Tue Oct 28 12:56:14 2025...
Press any key to continue . . . 
```